### PR TITLE
fix: collapse nested if statements to reduce clippy warnings

### DIFF
--- a/src/k8s/pods.rs
+++ b/src/k8s/pods.rs
@@ -30,26 +30,25 @@ fn get_pod_state(pod: &Pod) -> String {
     }
 
     // Then proceed to check the pod's status as before
-    if let Some(status) = &pod.status {
-        if let Some(phase) = &status.phase {
-            return match phase.as_str() {
-                "Pending" => "Pending".to_string(),
-                "Running" => {
-                    if status.conditions.as_ref().is_some_and(|conds| {
-                        conds
-                            .iter()
-                            .any(|c| c.type_ == "Ready" && c.status == "True")
-                    }) {
-                        "Running".to_string()
-                    } else {
-                        "Starting".to_string() // This might be a more accurate state for non-ready running pods
-                    }
+    if let Some(status) = &pod.status
+        && let Some(phase) = &status.phase {
+        return match phase.as_str() {
+            "Pending" => "Pending".to_string(),
+            "Running" => {
+                if status.conditions.as_ref().is_some_and(|conds| {
+                    conds
+                        .iter()
+                        .any(|c| c.type_ == "Ready" && c.status == "True")
+                }) {
+                    "Running".to_string()
+                } else {
+                    "Starting".to_string() // This might be a more accurate state for non-ready running pods
                 }
-                "Succeeded" => "Succeeded".to_string(),
-                "Failed" => "Failed".to_string(),
-                _ => "Unknown".to_string(),
-            };
-        }
+            }
+            "Succeeded" => "Succeeded".to_string(),
+            "Failed" => "Failed".to_string(),
+            _ => "Unknown".to_string(),
+        };
     }
 
     "Unknown".to_string()

--- a/src/k8s/rs_ingress.rs
+++ b/src/k8s/rs_ingress.rs
@@ -28,14 +28,10 @@ async fn services_for_rs(client: &Client, rs: &ReplicaSet, namespace: &str) -> R
     Ok(service_list
         .iter()
         .filter_map(|service| {
-            if let Some(svc_ref) = service.spec.as_ref() {
-                if let Some(selector) = svc_ref.selector.clone() {
-                    if matches_rs_labels(rs, &selector) {
-                        return service.metadata.name.clone();
-                    }
-                }
-            }
-            None
+            service.spec.as_ref()
+                .and_then(|svc_ref| svc_ref.selector.clone())
+                .filter(|selector| matches_rs_labels(rs, selector))
+                .and_then(|_| service.metadata.name.clone())
         })
         .collect())
 }

--- a/src/tui/pod_app/app.rs
+++ b/src/tui/pod_app/app.rs
@@ -120,16 +120,15 @@ impl AppBehavior for pod_app::app::App {
                             app_holder = Some(Apps::Pod { app: self.clone() });
                         }
                         Char('i' | 'I') => {
-                            if let Some(selection) = self.get_selected_item() {
-                                if let Some(selector) = selection.selectors.clone() {
-                                    let data_vec =
-                                        create_ingress_data_vec(selector.clone()).await?;
-                                    let new_app_holder = Apps::Ingress {
-                                        app: ingress_app::app::App::new(data_vec),
-                                    };
-                                    app_holder = Some(new_app_holder);
-                                    debug!("changing app from rs to ingress...");
-                                }
+                            if let Some(selection) = self.get_selected_item()
+                                && let Some(selector) = selection.selectors.clone() {
+                                let data_vec =
+                                    create_ingress_data_vec(selector.clone()).await?;
+                                let new_app_holder = Apps::Ingress {
+                                    app: ingress_app::app::App::new(data_vec),
+                                };
+                                app_holder = Some(new_app_holder);
+                                debug!("changing app from rs to ingress...");
                             }
                         }
                         Char('f' | 'F') if key.modifiers.contains(KeyModifiers::CONTROL) => {
@@ -139,18 +138,17 @@ impl AppBehavior for pod_app::app::App {
                             self.page_backward();
                         }
                         Enter => {
-                            if let Some(selection) = self.get_selected_item() {
-                                if let Some(selectors) = selection.selectors.clone() {
-                                    let data_vec = create_container_data_vec(
-                                        selectors,
-                                        selection.name.clone(),
-                                    )
-                                    .await?;
-                                    let new_app_holder = Apps::Container {
-                                        app: container_app::app::App::new(data_vec),
-                                    };
-                                    app_holder = Some(new_app_holder);
-                                }
+                            if let Some(selection) = self.get_selected_item()
+                                && let Some(selectors) = selection.selectors.clone() {
+                                let data_vec = create_container_data_vec(
+                                    selectors,
+                                    selection.name.clone(),
+                                )
+                                .await?;
+                                let new_app_holder = Apps::Container {
+                                    app: container_app::app::App::new(data_vec),
+                                };
+                                app_holder = Some(new_app_holder);
                             }
                         }
                         _k => {}


### PR DESCRIPTION
Fixes #392

This PR addresses the collapsible if statement issues appearing in the security tab from Rust Clippy static analysis.

## Changes
- Replace nested if let statements with let-else chains using `&&`
- Use functional combinators instead of nested if statements in rs_ingress.rs
- Fixes clippy::collapsible_if warnings in security tab

## Files Modified
- `src/k8s/rs_ingress.rs` - Used functional combinators for cleaner filter logic
- `src/tui/pod_app/app.rs` - Used let-else chains with `&&`
- `src/k8s/pods.rs` - Used let-else chain with `&&`

Generated with [Claude Code](https://claude.ai/code)