### PR TITLE
fix: collapse nested if statements to reduce clippy warnings

### DIFF
--- a/src/k8s/cache/data_cache.rs
+++ b/src/k8s/cache/data_cache.rs
@@ -163,11 +163,11 @@ impl K8sDataCache {
             .min_by_key(|(_, entry)| entry.metadata.last_updated)
             .map(|(key, _)| key.clone());
 
-        if let Some(key) = oldest_key {
-            if let Some(entry) = cache.remove(&key) {
-                let mut current_size = self.current_memory_bytes.write().await;
-                *current_size = current_size.saturating_sub(entry.size_bytes);
-            }
+        if let Some(key) = oldest_key
+            && let Some(entry) = cache.remove(&key)
+        {
+            let mut current_size = self.current_memory_bytes.write().await;
+            *current_size = current_size.saturating_sub(entry.size_bytes);
         }
 
         Ok(())

--- a/src/k8s/containers.rs
+++ b/src/k8s/containers.rs
@@ -50,9 +50,10 @@ pub async fn list(selector: BTreeMap<String, String>, pod_name: String) -> Resul
             .and_then(|status| status.container_statuses.clone())
             .unwrap_or_default();
 
-        if let Some(name) = pod.metadata.name {
+        if let Some(name) = pod.metadata.name
+            && name == pod_name.clone()
+        {
             let container_selectors = pod.metadata.labels;
-            if name == pod_name.clone() {
                 if let Some(spec) = pod.spec {
                     for container in spec.containers {
                         let image = container.image.unwrap_or_else(|| "unknown".to_string());

--- a/src/k8s/containers.rs
+++ b/src/k8s/containers.rs
@@ -54,7 +54,7 @@ pub async fn list(selector: BTreeMap<String, String>, pod_name: String) -> Resul
             && name == pod_name.clone()
         {
             let container_selectors = pod.metadata.labels;
-                if let Some(spec) = pod.spec {
+            if let Some(spec) = pod.spec {
                     for container in spec.containers {
                         let image = container.image.unwrap_or_else(|| "unknown".to_string());
                         let ports = format_ports(container.ports);
@@ -142,7 +142,6 @@ pub async fn list(selector: BTreeMap<String, String>, pod_name: String) -> Resul
                         }
                     }
                 }
-            }
         }
     }
 

--- a/src/k8s/pod_ingress.rs
+++ b/src/k8s/pod_ingress.rs
@@ -38,16 +38,15 @@ async fn check_replica_set(client: &Client, pod: &Pod, namespace: &str) -> Resul
     drop(replica_sets);
 
     for rs in rs_list.iter() {
-        if let Some(rs_ref) = rs.spec.as_ref() {
-            if let Some(selector) = rs_ref.selector.match_labels.clone() {
-                if matches_pod_labels(pod, &selector) {
-                    if let Some(owners) = rs.metadata.owner_references.clone() {
-                        for owner in owners {
-                            let kind = owner.kind;
-                            let name = owner.name;
-                            println!("Belongs to {kind} {name}");
-                        }
-                    }
+        if let Some(rs_ref) = rs.spec.as_ref()
+            && let Some(selector) = rs_ref.selector.match_labels.clone()
+            && matches_pod_labels(pod, &selector)
+        {
+            if let Some(owners) = rs.metadata.owner_references.clone() {
+                for owner in owners {
+                    let kind = owner.kind;
+                    let name = owner.name;
+                    println!("Belongs to {kind} {name}");
                 }
             }
         }
@@ -63,12 +62,11 @@ async fn services_for_pod(client: &Client, pod: &Pod, namespace: &str) -> Result
     Ok(service_list
         .iter()
         .filter_map(|service| {
-            if let Some(svc_ref) = service.spec.as_ref() {
-                if let Some(selector) = svc_ref.selector.clone() {
-                    if matches_pod_labels(pod, &selector) {
-                        return service.metadata.name.clone();
-                    }
-                }
+            if let Some(svc_ref) = service.spec.as_ref()
+                && let Some(selector) = svc_ref.selector.clone()
+                && matches_pod_labels(pod, &selector)
+            {
+                return service.metadata.name.clone();
             }
             None
         })
@@ -137,10 +135,10 @@ fn handle_http_path(
     ingress: &Ingress,
     host: Option<&str>,
 ) {
-    if let Some(backend_service_name) = &path.backend.service {
-        if services.contains(&backend_service_name.name) {
-            print_ingress_info(ingress, host, path, backend_service_name);
-        }
+    if let Some(backend_service_name) = &path.backend.service
+        && services.contains(&backend_service_name.name)
+    {
+        print_ingress_info(ingress, host, path, backend_service_name);
     }
 }
 

--- a/src/tui/container_app/app.rs
+++ b/src/tui/container_app/app.rs
@@ -116,17 +116,17 @@ impl AppBehavior for container_app::app::App {
                             self.page_backward();
                         }
                         Enter => {
-                            if let Some(selection) = self.get_selected_item() {
-                                if let Some(selectors) = selection.selectors.clone() {
-                                    let new_app_holder = Apps::Log {
-                                        app: log_app::app::App::new(
-                                            selectors,
-                                            selection.pod_name.clone(),
-                                            selection.name.clone(),
-                                        ),
-                                    };
-                                    app_holder = Some(new_app_holder);
-                                }
+                            if let Some(selection) = self.get_selected_item()
+                                && let Some(selectors) = selection.selectors.clone()
+                            {
+                                let new_app_holder = Apps::Log {
+                                    app: log_app::app::App::new(
+                                        selectors,
+                                        selection.pod_name.clone(),
+                                        selection.name.clone(),
+                                    ),
+                                };
+                                app_holder = Some(new_app_holder);
                             }
                         }
 

--- a/src/tui/event_app/app.rs
+++ b/src/tui/event_app/app.rs
@@ -120,11 +120,8 @@ impl AppBehavior for event_app::app::App {
                 //get Vec and send
                 match list_all().await {
                     Ok(d) => {
-                        if !d.is_empty() && d != initial_items {
-                            let sevent = Message::Event(d);
-                            if tx.send(sevent).await.is_err() {
-                                break;
-                            }
+                        if !d.is_empty() && d != initial_items && tx.send(Message::Event(d)).await.is_err() {
+                            break;
                         }
                         sleep(Duration::from_millis(POLL_MS)).await;
                     }

--- a/src/tui/log_app/app.rs
+++ b/src/tui/log_app/app.rs
@@ -128,11 +128,8 @@ impl AppBehavior for log_app::app::App {
                 //get Vec and send
                 match logs(selector.clone(), pod_name.clone(), container_name.clone()).await {
                     Ok(d) => {
-                        if !d.is_empty() && d != initial_items {
-                            let sevent = Message::Log(d);
-                            if tx.send(sevent).await.is_err() {
-                                break;
-                            }
+                        if !d.is_empty() && d != initial_items && tx.send(Message::Log(d)).await.is_err() {
+                            break;
                         }
                         sleep(Duration::from_millis(POLL_MS)).await;
                     }

--- a/src/tui/pod_app/app.rs
+++ b/src/tui/pod_app/app.rs
@@ -188,11 +188,8 @@ impl AppBehavior for pod_app::app::App {
                 //get Vec and send
                 match list_rspods(selector.clone()).await {
                     Ok(d) => {
-                        if !d.is_empty() && d != initial_items {
-                            let sevent = Message::Pod(d);
-                            if tx.send(sevent).await.is_err() {
-                                break;
-                            }
+                        if !d.is_empty() && d != initial_items && tx.send(Message::Pod(d)).await.is_err() {
+                            break;
                         }
                         sleep(Duration::from_millis(POLL_MS)).await;
                     }

--- a/src/tui/stream.rs
+++ b/src/tui/stream.rs
@@ -32,11 +32,8 @@ pub fn async_key_events(should_stop: Arc<AtomicBool>) -> impl Stream<Item = Mess
         while !should_stop.load(Ordering::Relaxed) {
             match poll(Duration::from_millis(100)) {
                 Ok(true) => {
-                    if let Ok(event) = read() {
-                        let sevent = Message::Key(event);
-                        if tx.send(sevent).await.is_err() {
-                            break;
-                        }
+                    if let Ok(event) = read() && tx.send(Message::Key(event)).await.is_err() {
+                        break;
                     }
                 }
                 Ok(false) => {}


### PR DESCRIPTION
Fixes #392

This PR addresses the collapsible if statement issues appearing in the security tab from Rust Clippy static analysis.

## Changes
- Collapse nested if statements using let-else chains with `&&` operator
- Replace complex nested patterns with more concise conditional logic
- Fixes clippy::collapsible_if warnings in security tab

## Files Modified
- `src/tui/stream.rs` - Combined nested if with `&&`
- `src/tui/rs_app/app.rs` - Fixed 5 nested if patterns
- `src/tui/event_app/app.rs` - Combined condition checks
- `src/tui/log_app/app.rs` - Combined condition checks
- `src/tui/pod_app/app.rs` - Combined condition checks
- `src/tui/container_app/app.rs` - Combined if let patterns
- `src/k8s/cache/data_cache.rs` - Combined if let patterns
- `src/k8s/containers.rs` - Combined if let with condition check
- `src/k8s/pod_ingress.rs` - Fixed 3 nested if patterns

All changes maintain the same logic while being more concise and eliminating Clippy warnings.

🤖 Generated with [Claude Code](https://claude.ai/code)