### PR TITLE
fix: resolve comparison function total order violation in event sorting

### DIFF
--- a/src/k8s/events.rs
+++ b/src/k8s/events.rs
@@ -50,14 +50,17 @@ pub async fn list_k8sevents(client: Client) -> Result<Vec<Event>, kube::Error> {
 
     let mut unfiltered_events: Vec<Event> = Api::default_namespaced(client).list(&lp).await?.items;
 
+    // Use a consistent fallback timestamp to ensure total order in comparison
+    let fallback_time = chrono::DateTime::<chrono::Utc>::from_timestamp(0, 0).unwrap_or_else(chrono::Utc::now);
+    
     unfiltered_events.sort_by(|a, b| {
         b.last_timestamp
             .clone()
-            .map_or_else(chrono::Utc::now, |t| t.0)
+            .map_or(fallback_time, |t| t.0)
             .cmp(
                 &a.last_timestamp
                     .clone()
-                    .map_or_else(chrono::Utc::now, |t| t.0),
+                    .map_or(fallback_time, |t| t.0),
             )
     });
 
@@ -76,14 +79,17 @@ pub async fn list_all() -> NvResult<Vec<ResourceEvent>> {
             .await?
             .items;
 
+    // Use a consistent fallback timestamp to ensure total order in comparison
+    let fallback_time = chrono::DateTime::<chrono::Utc>::from_timestamp(0, 0).unwrap_or_else(chrono::Utc::now);
+    
     unfiltered_events.sort_by(|a, b| {
         b.last_timestamp
             .clone()
-            .map_or_else(chrono::Utc::now, |t| t.0)
+            .map_or(fallback_time, |t| t.0)
             .cmp(
                 &a.last_timestamp
                     .clone()
-                    .map_or_else(chrono::Utc::now, |t| t.0),
+                    .map_or(fallback_time, |t| t.0),
             )
     });
 
@@ -119,14 +125,17 @@ pub async fn list_events_for_resource(
         })
         .collect();
 
+    // Use a consistent fallback timestamp to ensure total order in comparison
+    let fallback_time = chrono::DateTime::<chrono::Utc>::from_timestamp(0, 0).unwrap_or_else(chrono::Utc::now);
+    
     filtered_events.sort_by(|a, b| {
         b.last_timestamp
             .clone()
-            .map_or_else(chrono::Utc::now, |t| t.0)
+            .map_or(fallback_time, |t| t.0)
             .cmp(
                 &a.last_timestamp
                     .clone()
-                    .map_or_else(chrono::Utc::now, |t| t.0),
+                    .map_or(fallback_time, |t| t.0),
             )
     });
 


### PR DESCRIPTION
This PR fixes the panic reported in #399 by resolving a total order violation in the event sorting comparison function.

The issue was caused by using `chrono::Utc::now()` as a fallback value when sorting events, which created non-deterministic comparisons and violated Rust's total order requirement.

Fixes #399

Generated with [Claude Code](https://claude.ai/code)