### PR TITLE
slice 3

### DIFF
--- a/docs/design/workload-coverage.md
+++ b/docs/design/workload-coverage.md
@@ -91,18 +91,20 @@ shippable and leaves the tree in a working state.
   `Rs` row shape with `description = "DaemonSet"`. New cache variant,
   watch, prefetch chain, UI title now "Workloads". Proves the extension
   pattern.
-- **Slice 2 — StatefulSets.** Near-copy of Slice 1. Typed
+- **Slice 2 — StatefulSets.** ✅ *Merged.* Near-copy of Slice 1. Typed
   `Api<StatefulSet>`, status fields `ready_replicas` / `replicas`,
   `spec.selector.match_labels` for pod lookup. New `ss:` cache prefix,
   new `WatchedResource::StatefulSets`. No UI model changes beyond adding
   another kind tag.
-- **Slice 3 — Unowned leaf.** Highest user-visible payoff — unlocks
-  static-pod visibility (kube-apiserver, etcd, scheduler,
+- **Slice 3 — Unowned leaf.** ✅ *Merged.* Highest user-visible payoff —
+  unlocks static-pod visibility (kube-apiserver, etcd, scheduler,
   controller-manager). Not a typed K8s resource: synthesized from the
   existing pod fetch by filtering `owner_references` empty or
-  `kind = Node`. One synthetic row in the landing with the count;
-  selection routes to `pod_app` with a filter predicate (not a selector).
-  No new watch — reuses the Pods watch.
+  `kind = Node`. New `PodSelector::Unowned` variant drives both the
+  rs_app landing row and the pod_app drill-down; a shared `project_pod`
+  helper in `src/k8s/pods.rs` keeps projection logic DRY between
+  `list_rspods` and `list_unowned_pods`. No new watch — reuses the Pods
+  watch.
 - **Slice 4 — Jobs.** First slice where the selector model breaks:
   Job→Pod goes through `owner_references`, not `spec.selector`. Default
   filter `status.active > 0`; completed Jobs only visible via `/`.

--- a/src/k8s/cache/background_fetcher.rs
+++ b/src/k8s/cache/background_fetcher.rs
@@ -13,7 +13,7 @@ use tracing::{debug, error, info, warn};
 use crate::k8s::containers::list as list_containers;
 use crate::k8s::ds::list_daemonsets;
 use crate::k8s::events::list_all as list_events;
-use crate::k8s::pods::list_rspods;
+use crate::k8s::pods::{list_rspods, list_unowned_pods};
 use crate::k8s::rs::get_replicaset;
 use crate::k8s::rs::list_replicas;
 use crate::k8s::rs_ingress::list_ingresses;
@@ -354,14 +354,20 @@ impl BackgroundFetcher {
             DataRequest::Pods {
                 namespace: _,
                 selector,
-            } => {
-                let labels = match selector {
-                    super::fetcher::PodSelector::ByLabels(labels) => labels.clone(),
-                    _ => std::collections::BTreeMap::new(),
-                };
-                let data = list_rspods(labels).await?;
-                Ok(FetchResult::Pods(data))
-            }
+            } => match selector {
+                super::fetcher::PodSelector::Unowned => {
+                    let data = list_unowned_pods().await?;
+                    Ok(FetchResult::Pods(data))
+                }
+                super::fetcher::PodSelector::ByLabels(labels) => {
+                    let data = list_rspods(labels.clone()).await?;
+                    Ok(FetchResult::Pods(data))
+                }
+                _ => {
+                    let data = list_rspods(std::collections::BTreeMap::new()).await?;
+                    Ok(FetchResult::Pods(data))
+                }
+            },
             DataRequest::Containers {
                 pod_name,
                 namespace: _,

--- a/src/k8s/cache/background_fetcher.rs
+++ b/src/k8s/cache/background_fetcher.rs
@@ -363,9 +363,23 @@ impl BackgroundFetcher {
                     let data = list_rspods(labels.clone()).await?;
                     Ok(FetchResult::Pods(data))
                 }
-                _ => {
+                // `All` is what the refresh loop's `parse_cache_key` produces
+                // for any `pods:*` key whose selector it can't round-trip.
+                // Treat it as "fetch pods with no label filter" — matches
+                // the variant's documented intent and what list_rspods with
+                // empty labels already does.
+                super::fetcher::PodSelector::All => {
                     let data = list_rspods(std::collections::BTreeMap::new()).await?;
                     Ok(FetchResult::Pods(data))
+                }
+                // ByName has no fetcher yet; silently returning all pods
+                // would be actively wrong. Log and return empty.
+                super::fetcher::PodSelector::ByName(name) => {
+                    warn!(
+                        "📛 PodSelector::ByName({}) has no fetcher wired — returning empty",
+                        name
+                    );
+                    Ok(FetchResult::Pods(Vec::new()))
                 }
             },
             DataRequest::Containers {

--- a/src/k8s/cache/fetcher.rs
+++ b/src/k8s/cache/fetcher.rs
@@ -58,6 +58,9 @@ pub enum PodSelector {
     All,
     ByLabels(BTreeMap<String, String>),
     ByName(String),
+    /// Pods whose `owner_references` are missing or whose owner kind is
+    /// `Node` (static pods). Powers the synthesized "Unowned" workload row.
+    Unowned,
 }
 
 #[derive(Debug, Clone)]
@@ -207,5 +210,19 @@ mod tests {
             labels: BTreeMap::new(),
         };
         assert_eq!(req.cache_key(), "ss:all:{}");
+    }
+
+    #[test]
+    fn unowned_pod_selector_has_distinct_cache_key() {
+        let unowned = DataRequest::Pods {
+            namespace: "kube-system".to_string(),
+            selector: PodSelector::Unowned,
+        };
+        let empty_labels = DataRequest::Pods {
+            namespace: "kube-system".to_string(),
+            selector: PodSelector::ByLabels(BTreeMap::new()),
+        };
+        assert_ne!(unowned.cache_key(), empty_labels.cache_key());
+        assert!(unowned.cache_key().contains("Unowned"));
     }
 }

--- a/src/k8s/pods.rs
+++ b/src/k8s/pods.rs
@@ -1,12 +1,14 @@
 use crate::cache_manager::get_current_namespace_or_default;
 use crate::error::Result;
 use crate::k8s::events::{format_duration, list_events_for_resource, list_k8sevents};
-use crate::k8s::metrics_client::{create_metrics_lookup, fetch_node_metrics, fetch_pod_metrics};
+use crate::k8s::metrics_client::{
+    ContainerMetric, create_metrics_lookup, fetch_node_metrics, fetch_pod_metrics,
+};
 use crate::k8s::resources::{format_cpu, format_memory, parse_cpu, parse_memory};
 use crate::k8s::utils::format_label_selector;
 use crate::tui::data::RsPod;
 use chrono::{DateTime, Utc};
-use k8s_openapi::api::core::v1::{Node, Pod};
+use k8s_openapi::api::core::v1::{Event, Node, Pod};
 use kube::Api;
 use kube::api::ListParams;
 use std::collections::{BTreeMap, HashMap};
@@ -62,24 +64,246 @@ fn get_pod_state(pod: &Pod) -> String {
     "Unknown".to_string()
 }
 
-/// # Errors
+/// Build a `node_name -> (cpu_percent, memory_percent)` lookup from nodes + metrics.
+fn build_node_info(
+    nodes: &[Node],
+    node_metrics: &[crate::k8s::metrics_client::NodeMetric],
+) -> HashMap<String, (f64, f64)> {
+    let mut node_info: HashMap<String, (f64, f64)> = HashMap::new();
+    for node in nodes {
+        let Some(node_name) = &node.metadata.name else {
+            continue;
+        };
+
+        let (cpu_capacity, mem_capacity) = node
+            .status
+            .as_ref()
+            .and_then(|status| status.capacity.as_ref())
+            .map_or((None, None), |capacity| {
+                let cpu = capacity.get("cpu").and_then(|q| parse_cpu(&q.0));
+                let mem = capacity.get("memory").and_then(|q| parse_memory(&q.0));
+                (cpu, mem)
+            });
+
+        let (cpu_usage, mem_usage) = node_metrics
+            .iter()
+            .find(|nm| nm.node_name == *node_name)
+            .map_or((None, None), |nm| (nm.cpu_usage, nm.memory_usage));
+
+        let cpu_pct = match (cpu_usage, cpu_capacity) {
+            (Some(usage), Some(capacity)) if capacity > 0.0 => Some((usage / capacity) * 100.0),
+            _ => None,
+        };
+        #[allow(clippy::cast_precision_loss)]
+        let mem_pct = match (mem_usage, mem_capacity) {
+            (Some(usage), Some(capacity)) if capacity > 0 => {
+                Some((usage as f64 / capacity as f64) * 100.0)
+            }
+            _ => None,
+        };
+
+        if let (Some(cpu), Some(mem)) = (cpu_pct, mem_pct) {
+            node_info.insert(node_name.clone(), (cpu, mem));
+        }
+    }
+    node_info
+}
+
+/// Project a single `Pod` into an `RsPod` row using the supplied auxiliary lookups.
 ///
-/// Will return `Err` if data can not be retrieved from k8s cluster api
-#[allow(clippy::significant_drop_tightening)]
+/// `kind` is the value written to `RsPod.description` (e.g. `"ReplicaSet"`,
+/// `"Unowned"`). Events are filtered to this pod's name inside the helper.
 #[allow(clippy::too_many_lines)]
-pub async fn list_rspods(selector: BTreeMap<String, String>) -> Result<Vec<RsPod>> {
-    let client = new(Some(USER_AGENT)).await?;
+async fn project_pod(
+    pod: &Pod,
+    kind: &str,
+    events: &[Event],
+    metrics_lookup: &HashMap<String, HashMap<String, ContainerMetric>>,
+    node_info: &HashMap<String, (f64, f64)>,
+) -> Result<RsPod> {
+    let instance_name = pod
+        .metadata
+        .name
+        .clone()
+        .unwrap_or_else(|| "unknown".to_string());
 
-    // Format the label selector from the BTreeMap
-    let label_selector = format_label_selector(&selector);
+    let actual_container_count = pod.status.as_ref().map_or(0, |status| {
+        status
+            .container_statuses
+            .as_ref()
+            .map_or(0, |container_statuses| {
+                container_statuses.iter().filter(|cs| cs.ready).count()
+            })
+    });
 
-    // Apply the label selector in ListParams
-    let lp = ListParams::default().labels(&label_selector);
+    let desired_container_count = pod.spec.as_ref().map_or(0, |spec| spec.containers.len());
 
-    // Fetch all data in parallel to reduce latency
+    let age = calculate_pod_age(pod);
+    let status = get_pod_state(pod);
+    let selectors = pod.metadata.labels.clone();
+
+    let resource_events = list_events_for_resource(events.to_vec(), &instance_name).await?;
+
+    let (cpu_request, cpu_limit, memory_request, memory_limit) =
+        pod.spec.as_ref().map_or((None, None, None, None), |spec| {
+            let mut total_cpu_req = 0.0;
+            let mut total_cpu_lim = 0.0;
+            let mut total_mem_req = 0u64;
+            let mut total_mem_lim = 0u64;
+            let mut has_cpu_req = false;
+            let mut has_cpu_lim = false;
+            let mut has_mem_req = false;
+            let mut has_mem_lim = false;
+
+            for container in &spec.containers {
+                if let Some(ref resources) = container.resources {
+                    if let Some(ref requests) = resources.requests {
+                        if let Some(cpu) = requests.get("cpu")
+                            && let Some(val) = parse_cpu(&cpu.0)
+                        {
+                            total_cpu_req += val;
+                            has_cpu_req = true;
+                        }
+                        if let Some(mem) = requests.get("memory")
+                            && let Some(val) = parse_memory(&mem.0)
+                        {
+                            total_mem_req += val;
+                            has_mem_req = true;
+                        }
+                    }
+                    if let Some(ref limits) = resources.limits {
+                        if let Some(cpu) = limits.get("cpu")
+                            && let Some(val) = parse_cpu(&cpu.0)
+                        {
+                            total_cpu_lim += val;
+                            has_cpu_lim = true;
+                        }
+                        if let Some(mem) = limits.get("memory")
+                            && let Some(val) = parse_memory(&mem.0)
+                        {
+                            total_mem_lim += val;
+                            has_mem_lim = true;
+                        }
+                    }
+                }
+            }
+
+            (
+                if has_cpu_req {
+                    Some(format_cpu(total_cpu_req))
+                } else {
+                    None
+                },
+                if has_cpu_lim {
+                    Some(format_cpu(total_cpu_lim))
+                } else {
+                    None
+                },
+                if has_mem_req {
+                    Some(format_memory(total_mem_req))
+                } else {
+                    None
+                },
+                if has_mem_lim {
+                    Some(format_memory(total_mem_lim))
+                } else {
+                    None
+                },
+            )
+        });
+
+    let (cpu_usage, memory_usage) =
+        metrics_lookup
+            .get(&instance_name)
+            .map_or((None, None), |container_metrics| {
+                let mut total_cpu_usage = 0.0;
+                let mut total_mem_usage = 0u64;
+                let mut has_cpu_usage = false;
+                let mut has_mem_usage = false;
+
+                for metric in container_metrics.values() {
+                    if let Some(cpu) = metric.cpu_usage {
+                        total_cpu_usage += cpu;
+                        has_cpu_usage = true;
+                    }
+                    if let Some(mem) = metric.memory_usage {
+                        total_mem_usage += mem;
+                        has_mem_usage = true;
+                    }
+                }
+
+                crate::cache_manager::record_pod_metrics(
+                    &instance_name,
+                    if has_cpu_usage {
+                        Some(total_cpu_usage)
+                    } else {
+                        None
+                    },
+                    if has_mem_usage {
+                        Some(total_mem_usage)
+                    } else {
+                        None
+                    },
+                );
+
+                (
+                    if has_cpu_usage {
+                        Some(format_cpu(total_cpu_usage))
+                    } else {
+                        None
+                    },
+                    if has_mem_usage {
+                        Some(format_memory(total_mem_usage))
+                    } else {
+                        None
+                    },
+                )
+            });
+
+    let node_name = pod.spec.as_ref().and_then(|spec| spec.node_name.clone());
+    let (node_cpu_percent, node_memory_percent) = node_name
+        .as_ref()
+        .and_then(|name| node_info.get(name))
+        .map_or((None, None), |(cpu, mem)| (Some(*cpu), Some(*mem)));
+
+    Ok(RsPod {
+        name: instance_name,
+        status,
+        description: kind.to_string(),
+        age,
+        containers: format!("{actual_container_count}/{desired_container_count}"),
+        selectors,
+        events: resource_events,
+        cpu_request,
+        cpu_limit,
+        cpu_usage,
+        memory_request,
+        memory_limit,
+        memory_usage,
+        node_name,
+        node_cpu_percent,
+        node_memory_percent,
+    })
+}
+
+/// Fetch pods, events, metrics, and nodes in parallel for projection.
+///
+/// Shared between `list_rspods` (label-selected, owner-filtered) and
+/// `list_unowned_pods` (unselected, filter-predicate).
+#[allow(clippy::type_complexity)]
+async fn load_pod_projection_inputs(
+    client: &kube::Client,
+    label_selector: &str,
+) -> Result<(
+    Vec<Pod>,
+    Vec<Event>,
+    HashMap<String, HashMap<String, ContainerMetric>>,
+    HashMap<String, (f64, f64)>,
+)> {
     let namespace = get_current_namespace_or_default();
     let pods_api: Api<Pod> = Api::namespaced(client.clone(), &namespace);
     let nodes_api: Api<Node> = Api::all(client.clone());
+    let lp = ListParams::default().labels(label_selector);
     let node_lp = ListParams::default();
 
     let (pod_list_result, events_result, pod_metrics_result, node_list_result, node_metrics_result) = tokio::join!(
@@ -92,7 +316,6 @@ pub async fn list_rspods(selector: BTreeMap<String, String>) -> Result<Vec<RsPod
 
     let pod_list = pod_list_result?;
     let events = events_result?;
-
     let pod_metrics = pod_metrics_result.unwrap_or_else(|e| {
         debug!("Could not fetch pod metrics: {}", e);
         Vec::new()
@@ -104,227 +327,60 @@ pub async fn list_rspods(selector: BTreeMap<String, String>) -> Result<Vec<RsPod
         debug!("Could not fetch node metrics: {}", e);
         Vec::new()
     });
+    let node_info = build_node_info(&node_list.items, &node_metrics);
+
+    Ok((pod_list.items, events, metrics_lookup, node_info))
+}
+
+/// # Errors
+///
+/// Will return `Err` if data can not be retrieved from k8s cluster api
+pub async fn list_rspods(selector: BTreeMap<String, String>) -> Result<Vec<RsPod>> {
+    let client = new(Some(USER_AGENT)).await?;
+    let label_selector = format_label_selector(&selector);
+
+    let (pods, events, metrics_lookup, node_info) =
+        load_pod_projection_inputs(&client, &label_selector).await?;
 
     let mut pod_vec = Vec::new();
-
-    // Build node info lookup: node_name -> (cpu_percent, memory_percent)
-    let mut node_info: HashMap<String, (f64, f64)> = HashMap::new();
-    for node in &node_list.items {
-        if let Some(node_name) = &node.metadata.name {
-            // Get capacity from node spec
-            let (cpu_capacity, mem_capacity) = node
-                .status
-                .as_ref()
-                .and_then(|status| status.capacity.as_ref())
-                .map_or((None, None), |capacity| {
-                    let cpu = capacity.get("cpu").and_then(|q| parse_cpu(&q.0));
-                    let mem = capacity.get("memory").and_then(|q| parse_memory(&q.0));
-                    (cpu, mem)
-                });
-
-            // Get usage from metrics
-            let (cpu_usage, mem_usage) = node_metrics
-                .iter()
-                .find(|nm| nm.node_name == *node_name)
-                .map_or((None, None), |nm| (nm.cpu_usage, nm.memory_usage));
-
-            // Calculate percentages
-            let cpu_pct = match (cpu_usage, cpu_capacity) {
-                (Some(usage), Some(capacity)) if capacity > 0.0 => Some((usage / capacity) * 100.0),
-                _ => None,
-            };
-            #[allow(clippy::cast_precision_loss)]
-            let mem_pct = match (mem_usage, mem_capacity) {
-                (Some(usage), Some(capacity)) if capacity > 0 => {
-                    Some((usage as f64 / capacity as f64) * 100.0)
-                }
-                _ => None,
-            };
-
-            if let (Some(cpu), Some(mem)) = (cpu_pct, mem_pct) {
-                node_info.insert(node_name.clone(), (cpu, mem));
+    for pod in pods {
+        if let Some(owners) = &pod.metadata.owner_references {
+            for owner in owners {
+                let rs_pod =
+                    project_pod(&pod, &owner.kind, &events, &metrics_lookup, &node_info).await?;
+                pod_vec.push(rs_pod);
             }
         }
     }
 
-    for pod in pod_list.items {
-        if let Some(owners) = &pod.metadata.owner_references {
-            for owner in owners {
-                let instance_name = &pod
-                    .metadata
-                    .name
-                    .clone()
-                    .unwrap_or_else(|| "unknown".to_string()); // Fixed typo in "unknown"
+    Ok(pod_vec)
+}
 
-                // Adjusted actual container count to reflect only ready containers
-                let actual_container_count = pod.status.as_ref().map_or(0, |status| {
-                    status
-                        .container_statuses
-                        .as_ref()
-                        .map_or(0, |container_statuses| {
-                            container_statuses.iter().filter(|cs| cs.ready).count()
-                        })
-                });
+/// List pods no workload controller owns.
+///
+/// Covers pods with no `owner_references` and static pods (owner kind
+/// `Node`) — e.g. kube-apiserver/scheduler/controller-manager on a kubeadm
+/// cluster. Powers the synthesized "Unowned" row in the workloads landing.
+///
+/// # Errors
+///
+/// Will return `Err` if data can not be retrieved from k8s cluster api
+pub async fn list_unowned_pods() -> Result<Vec<RsPod>> {
+    let client = new(Some(USER_AGENT)).await?;
 
-                // Desired container count remains the same
-                let desired_container_count =
-                    pod.spec.as_ref().map_or(0, |spec| spec.containers.len());
-                let kind = &owner.kind;
+    let (pods, events, metrics_lookup, node_info) = load_pod_projection_inputs(&client, "").await?;
 
-                let age = calculate_pod_age(&pod);
-                let status = get_pod_state(&pod);
-                let selectors = pod.metadata.labels.clone();
-
-                let resource_events =
-                    list_events_for_resource(events.clone(), instance_name).await?;
-
-                // Aggregate resource requests and limits from all containers
-                let (cpu_request, cpu_limit, memory_request, memory_limit) =
-                    pod.spec.as_ref().map_or((None, None, None, None), |spec| {
-                        let mut total_cpu_req = 0.0;
-                        let mut total_cpu_lim = 0.0;
-                        let mut total_mem_req = 0u64;
-                        let mut total_mem_lim = 0u64;
-                        let mut has_cpu_req = false;
-                        let mut has_cpu_lim = false;
-                        let mut has_mem_req = false;
-                        let mut has_mem_lim = false;
-
-                        for container in &spec.containers {
-                            if let Some(ref resources) = container.resources {
-                                if let Some(ref requests) = resources.requests {
-                                    if let Some(cpu) = requests.get("cpu")
-                                        && let Some(val) = parse_cpu(&cpu.0)
-                                    {
-                                        total_cpu_req += val;
-                                        has_cpu_req = true;
-                                    }
-                                    if let Some(mem) = requests.get("memory")
-                                        && let Some(val) = parse_memory(&mem.0)
-                                    {
-                                        total_mem_req += val;
-                                        has_mem_req = true;
-                                    }
-                                }
-                                if let Some(ref limits) = resources.limits {
-                                    if let Some(cpu) = limits.get("cpu")
-                                        && let Some(val) = parse_cpu(&cpu.0)
-                                    {
-                                        total_cpu_lim += val;
-                                        has_cpu_lim = true;
-                                    }
-                                    if let Some(mem) = limits.get("memory")
-                                        && let Some(val) = parse_memory(&mem.0)
-                                    {
-                                        total_mem_lim += val;
-                                        has_mem_lim = true;
-                                    }
-                                }
-                            }
-                        }
-
-                        (
-                            if has_cpu_req {
-                                Some(format_cpu(total_cpu_req))
-                            } else {
-                                None
-                            },
-                            if has_cpu_lim {
-                                Some(format_cpu(total_cpu_lim))
-                            } else {
-                                None
-                            },
-                            if has_mem_req {
-                                Some(format_memory(total_mem_req))
-                            } else {
-                                None
-                            },
-                            if has_mem_lim {
-                                Some(format_memory(total_mem_lim))
-                            } else {
-                                None
-                            },
-                        )
-                    });
-
-                // Get actual usage from metrics
-                let (cpu_usage, memory_usage) =
-                    metrics_lookup
-                        .get(instance_name)
-                        .map_or((None, None), |container_metrics| {
-                            let mut total_cpu_usage = 0.0;
-                            let mut total_mem_usage = 0u64;
-                            let mut has_cpu_usage = false;
-                            let mut has_mem_usage = false;
-
-                            for metric in container_metrics.values() {
-                                if let Some(cpu) = metric.cpu_usage {
-                                    total_cpu_usage += cpu;
-                                    has_cpu_usage = true;
-                                }
-                                if let Some(mem) = metric.memory_usage {
-                                    total_mem_usage += mem;
-                                    has_mem_usage = true;
-                                }
-                            }
-
-                            // Record metrics in history for trend visualization
-                            crate::cache_manager::record_pod_metrics(
-                                instance_name,
-                                if has_cpu_usage {
-                                    Some(total_cpu_usage)
-                                } else {
-                                    None
-                                },
-                                if has_mem_usage {
-                                    Some(total_mem_usage)
-                                } else {
-                                    None
-                                },
-                            );
-
-                            (
-                                if has_cpu_usage {
-                                    Some(format_cpu(total_cpu_usage))
-                                } else {
-                                    None
-                                },
-                                if has_mem_usage {
-                                    Some(format_memory(total_mem_usage))
-                                } else {
-                                    None
-                                },
-                            )
-                        });
-
-                // Get node info for this pod
-                let node_name = pod.spec.as_ref().and_then(|spec| spec.node_name.clone());
-                let (node_cpu_percent, node_memory_percent) = node_name
-                    .as_ref()
-                    .and_then(|name| node_info.get(name))
-                    .map_or((None, None), |(cpu, mem)| (Some(*cpu), Some(*mem)));
-
-                let data = RsPod {
-                    name: instance_name.clone(),
-                    status: status.clone(),
-                    description: kind.clone(),
-                    age,
-                    containers: format!("{actual_container_count}/{desired_container_count}"),
-                    selectors,
-                    events: resource_events,
-                    cpu_request,
-                    cpu_limit,
-                    cpu_usage,
-                    memory_request,
-                    memory_limit,
-                    memory_usage,
-                    node_name,
-                    node_cpu_percent,
-                    node_memory_percent,
-                };
-
-                pod_vec.push(data);
-            }
+    let mut pod_vec = Vec::new();
+    for pod in pods {
+        let kind = match pod.metadata.owner_references.as_ref() {
+            None => Some("Unowned"),
+            Some(refs) if refs.is_empty() => Some("Unowned"),
+            Some(refs) if refs.iter().all(|o| o.kind == "Node") => Some("StaticPod"),
+            Some(_) => None,
+        };
+        if let Some(kind) = kind {
+            let rs_pod = project_pod(&pod, kind, &events, &metrics_lookup, &node_info).await?;
+            pod_vec.push(rs_pod);
         }
     }
 

--- a/src/k8s/pods.rs
+++ b/src/k8s/pods.rs
@@ -286,20 +286,24 @@ async fn project_pod(
     })
 }
 
+/// Bundle of per-call auxiliary data consumed by `project_pod`.
+///
+/// Named so callers don't have to carry the 4-tuple shape around.
+struct PodProjectionInputs {
+    pods: Vec<Pod>,
+    events: Vec<Event>,
+    metrics_lookup: HashMap<String, HashMap<String, ContainerMetric>>,
+    node_info: HashMap<String, (f64, f64)>,
+}
+
 /// Fetch pods, events, metrics, and nodes in parallel for projection.
 ///
 /// Shared between `list_rspods` (label-selected, owner-filtered) and
 /// `list_unowned_pods` (unselected, filter-predicate).
-#[allow(clippy::type_complexity)]
 async fn load_pod_projection_inputs(
     client: &kube::Client,
     label_selector: &str,
-) -> Result<(
-    Vec<Pod>,
-    Vec<Event>,
-    HashMap<String, HashMap<String, ContainerMetric>>,
-    HashMap<String, (f64, f64)>,
-)> {
+) -> Result<PodProjectionInputs> {
     let namespace = get_current_namespace_or_default();
     let pods_api: Api<Pod> = Api::namespaced(client.clone(), &namespace);
     let nodes_api: Api<Node> = Api::all(client.clone());
@@ -329,7 +333,12 @@ async fn load_pod_projection_inputs(
     });
     let node_info = build_node_info(&node_list.items, &node_metrics);
 
-    Ok((pod_list.items, events, metrics_lookup, node_info))
+    Ok(PodProjectionInputs {
+        pods: pod_list.items,
+        events,
+        metrics_lookup,
+        node_info,
+    })
 }
 
 /// # Errors
@@ -339,15 +348,20 @@ pub async fn list_rspods(selector: BTreeMap<String, String>) -> Result<Vec<RsPod
     let client = new(Some(USER_AGENT)).await?;
     let label_selector = format_label_selector(&selector);
 
-    let (pods, events, metrics_lookup, node_info) =
-        load_pod_projection_inputs(&client, &label_selector).await?;
+    let inputs = load_pod_projection_inputs(&client, &label_selector).await?;
 
     let mut pod_vec = Vec::new();
-    for pod in pods {
+    for pod in inputs.pods {
         if let Some(owners) = &pod.metadata.owner_references {
             for owner in owners {
-                let rs_pod =
-                    project_pod(&pod, &owner.kind, &events, &metrics_lookup, &node_info).await?;
+                let rs_pod = project_pod(
+                    &pod,
+                    &owner.kind,
+                    &inputs.events,
+                    &inputs.metrics_lookup,
+                    &inputs.node_info,
+                )
+                .await?;
                 pod_vec.push(rs_pod);
             }
         }
@@ -368,21 +382,105 @@ pub async fn list_rspods(selector: BTreeMap<String, String>) -> Result<Vec<RsPod
 pub async fn list_unowned_pods() -> Result<Vec<RsPod>> {
     let client = new(Some(USER_AGENT)).await?;
 
-    let (pods, events, metrics_lookup, node_info) = load_pod_projection_inputs(&client, "").await?;
+    let inputs = load_pod_projection_inputs(&client, "").await?;
 
     let mut pod_vec = Vec::new();
-    for pod in pods {
-        let kind = match pod.metadata.owner_references.as_ref() {
-            None => Some("Unowned"),
-            Some(refs) if refs.is_empty() => Some("Unowned"),
-            Some(refs) if refs.iter().all(|o| o.kind == "Node") => Some("StaticPod"),
-            Some(_) => None,
-        };
-        if let Some(kind) = kind {
-            let rs_pod = project_pod(&pod, kind, &events, &metrics_lookup, &node_info).await?;
+    for pod in inputs.pods {
+        if let Some(kind) = classify_unowned_pod(&pod) {
+            let rs_pod = project_pod(
+                &pod,
+                kind,
+                &inputs.events,
+                &inputs.metrics_lookup,
+                &inputs.node_info,
+            )
+            .await?;
             pod_vec.push(rs_pod);
         }
     }
 
     Ok(pod_vec)
+}
+
+/// Classify a pod for the Unowned leaf.
+///
+/// Returns `Some("Unowned")` for pods with no `owner_references` (or an
+/// empty list), `Some("StaticPod")` when every owner is a `Node` (kubelet
+/// mirror pods like kube-apiserver/etcd on a kubeadm control plane), and
+/// `None` when any workload controller owns the pod — those belong under
+/// their workload row, not the Unowned leaf.
+fn classify_unowned_pod(pod: &Pod) -> Option<&'static str> {
+    match pod.metadata.owner_references.as_ref() {
+        None => Some("Unowned"),
+        Some(refs) if refs.is_empty() => Some("Unowned"),
+        Some(refs) if refs.iter().all(|o| o.kind == "Node") => Some("StaticPod"),
+        Some(_) => None,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::classify_unowned_pod;
+    use k8s_openapi::api::core::v1::Pod;
+    use k8s_openapi::apimachinery::pkg::apis::meta::v1::{ObjectMeta, OwnerReference};
+
+    fn pod_with_owners(owners: Option<Vec<OwnerReference>>) -> Pod {
+        Pod {
+            metadata: ObjectMeta {
+                owner_references: owners,
+                ..ObjectMeta::default()
+            },
+            ..Pod::default()
+        }
+    }
+
+    fn owner(kind: &str) -> OwnerReference {
+        OwnerReference {
+            kind: kind.to_string(),
+            ..OwnerReference::default()
+        }
+    }
+
+    #[test]
+    fn classify_none_owners_is_unowned() {
+        assert_eq!(
+            classify_unowned_pod(&pod_with_owners(None)),
+            Some("Unowned")
+        );
+    }
+
+    #[test]
+    fn classify_empty_owners_is_unowned() {
+        assert_eq!(
+            classify_unowned_pod(&pod_with_owners(Some(Vec::new()))),
+            Some("Unowned"),
+        );
+    }
+
+    #[test]
+    fn classify_all_node_owners_is_static_pod() {
+        assert_eq!(
+            classify_unowned_pod(&pod_with_owners(Some(vec![owner("Node")]))),
+            Some("StaticPod"),
+        );
+    }
+
+    #[test]
+    fn classify_workload_owner_returns_none() {
+        assert_eq!(
+            classify_unowned_pod(&pod_with_owners(Some(vec![owner("ReplicaSet")]))),
+            None,
+        );
+    }
+
+    #[test]
+    fn classify_mixed_node_and_workload_owners_returns_none() {
+        assert_eq!(
+            classify_unowned_pod(&pod_with_owners(Some(vec![
+                owner("Node"),
+                owner("ReplicaSet")
+            ]))),
+            None,
+        );
+    }
 }

--- a/src/tui/container_app/app.rs
+++ b/src/tui/container_app/app.rs
@@ -199,7 +199,9 @@ impl App {
                     let data_vec = vec![];
                     return Apps::Pod {
                         app: crate::tui::pod_app::app::App::new(
-                            std::collections::BTreeMap::new(),
+                            crate::k8s::cache::PodSelector::ByLabels(
+                                std::collections::BTreeMap::new(),
+                            ),
                             data_vec,
                         ),
                     };

--- a/src/tui/pod_app/app.rs
+++ b/src/tui/pod_app/app.rs
@@ -18,7 +18,6 @@ use crossterm::event::{Event, KeyCode, KeyEventKind};
 use futures::Stream;
 use ratatui::prelude::*;
 use ratatui::widgets::ScrollbarState;
-use std::collections::BTreeMap;
 use std::io;
 use std::sync::Arc;
 use std::sync::atomic::{AtomicBool, Ordering};
@@ -33,7 +32,7 @@ const POLL_MS: u64 = 1000;
 #[derive(Clone, Debug)]
 pub struct App {
     pub(crate) base: BaseTableState<RsPod>,
-    pub(crate) selector: BTreeMap<String, String>,
+    pub(crate) selector: PodSelector,
 }
 
 impl_tui_table_state!(App, RsPod);
@@ -82,7 +81,7 @@ impl AppBehavior for pod_app::app::App {
             let cache = cache_manager::get_cache_or_default();
             let request = DataRequest::Pods {
                 namespace: cache_manager::get_current_namespace_or_default(),
-                selector: PodSelector::ByLabels(selector.clone()),
+                selector: selector.clone(),
             };
 
             debug!("Pod app requesting cache key: {}", request.cache_key());
@@ -163,7 +162,7 @@ impl AppBehavior for pod_app::app::App {
 }
 
 impl App {
-    pub fn new(selector: BTreeMap<String, String>, data_vec: Vec<RsPod>) -> Self {
+    pub fn new(selector: PodSelector, data_vec: Vec<RsPod>) -> Self {
         Self {
             base: BaseTableState::new(data_vec),
             selector,

--- a/src/tui/rs_app/app.rs
+++ b/src/tui/rs_app/app.rs
@@ -1,12 +1,13 @@
 use crate::cache_manager;
 use crate::impl_tui_table_state;
-use crate::k8s::cache::{DataRequest, FetchResult};
+use crate::k8s::cache::{DataRequest, FetchResult, PodSelector};
 use crate::k8s::ds::list_daemonsets;
+use crate::k8s::pods::list_unowned_pods;
 use crate::k8s::rs::list_replicas;
 use crate::k8s::ss::list_statefulsets;
 use crate::tui::common::base_table_state::BaseTableState;
 use crate::tui::common::key_handler::{KeyHandlerResult, handle_common_keys};
-use crate::tui::data::Rs;
+use crate::tui::data::{Rs, RsPod};
 use crate::tui::pod_app;
 // use crate::tui::rs_app::ui; // Unused while testing modern UI
 use crate::tui::rs_app::domain::ReplicaSetDomainService;
@@ -80,8 +81,12 @@ impl AppBehavior for App {
                 labels: std::collections::BTreeMap::new(),
             };
             let ss_request = DataRequest::StatefulSets {
-                namespace: Some(namespace),
+                namespace: Some(namespace.clone()),
                 labels: std::collections::BTreeMap::new(),
+            };
+            let unowned_request = DataRequest::Pods {
+                namespace,
+                selector: PodSelector::Unowned,
             };
 
             // Subscribe to cache updates for all workload kinds so we
@@ -97,6 +102,10 @@ impl AppBehavior for App {
             let (ss_sub_id, mut ss_rx) = cache
                 .subscription_manager
                 .subscribe("ss:*".to_string())
+                .await;
+            let (pods_sub_id, mut pods_rx) = cache
+                .subscription_manager
+                .subscribe("pods:*".to_string())
                 .await;
 
             let mut last_sent = initial_items;
@@ -116,19 +125,29 @@ impl AppBehavior for App {
                     Some(FetchResult::StatefulSets(v)) => v,
                     _ => Vec::new(),
                 };
+                let unowned_items = match cache.get(&unowned_request).await {
+                    Some(FetchResult::Pods(v)) => v,
+                    _ => Vec::new(),
+                };
 
                 let mut merged = if rs_items.is_empty()
                     && ds_items.is_empty()
                     && ss_items.is_empty()
+                    && unowned_items.is_empty()
                 {
-                    debug!("Workloads stream: cold cache, fetching RS+DS+SS in parallel");
+                    debug!("Workloads stream: cold cache, fetching RS+DS+SS+Unowned in parallel");
                     cache_manager::start_blocking_operation();
-                    let (rs_res, ds_res, ss_res) =
-                        tokio::join!(list_replicas(), list_daemonsets(), list_statefulsets());
+                    let (rs_res, ds_res, ss_res, unowned_res) = tokio::join!(
+                        list_replicas(),
+                        list_daemonsets(),
+                        list_statefulsets(),
+                        list_unowned_pods()
+                    );
                     cache_manager::end_blocking_operation();
                     let rs_fetch = rs_res.unwrap_or_default();
                     let ds_fetch = ds_res.unwrap_or_default();
                     let ss_fetch = ss_res.unwrap_or_default();
+                    let unowned_fetch = unowned_res.unwrap_or_default();
 
                     if !rs_fetch.is_empty() {
                         let _ = cache
@@ -148,10 +167,15 @@ impl AppBehavior for App {
                             .await;
                         ReplicaSetDomainService::trigger_pod_prefetch(&ss_fetch, "IMMEDIATE").await;
                     }
+                    if !unowned_fetch.is_empty() {
+                        let _ = cache
+                            .put(&unowned_request, FetchResult::Pods(unowned_fetch.clone()))
+                            .await;
+                    }
 
-                    merge_workloads(rs_fetch, ds_fetch, ss_fetch)
+                    merge_workloads(rs_fetch, ds_fetch, ss_fetch, &unowned_fetch)
                 } else {
-                    merge_workloads(rs_items, ds_items, ss_items)
+                    merge_workloads(rs_items, ds_items, ss_items, &unowned_items)
                 };
 
                 if !merged.is_empty() && merged != last_sent {
@@ -159,6 +183,7 @@ impl AppBehavior for App {
                         cache.subscription_manager.unsubscribe(&rs_sub_id).await;
                         cache.subscription_manager.unsubscribe(&ds_sub_id).await;
                         cache.subscription_manager.unsubscribe(&ss_sub_id).await;
+                        cache.subscription_manager.unsubscribe(&pods_sub_id).await;
                         return;
                     }
                     std::mem::swap(&mut last_sent, &mut merged);
@@ -184,6 +209,13 @@ impl AppBehavior for App {
                     update = ss_rx.recv() => {
                         if let Some(crate::k8s::cache::DataUpdate::StatefulSets(v)) = update {
                             ReplicaSetDomainService::trigger_pod_prefetch(&v, "UPDATE").await;
+                            refresh = true;
+                        }
+                    }
+                    update = pods_rx.recv() => {
+                        // Any pod cache update may change the Unowned count. We
+                        // don't care which selector fired — just re-merge.
+                        if update.is_some() {
                             refresh = true;
                         }
                     }
@@ -274,7 +306,34 @@ impl AppBehavior for App {
                     }
                 };
 
-                let mut merged = merge_workloads(rs_items, ds_items, ss_items);
+                let unowned_items =
+                    if let Some(FetchResult::Pods(v)) = cache.get(&unowned_request).await {
+                        v
+                    } else {
+                        // Cache miss for Unowned: most clusters have zero, so
+                        // this path rarely runs. Still blocking like RS/DS/SS
+                        // to keep the landing consistent.
+                        debug!("Workloads stream: Unowned cache miss, direct fetch");
+                        cache_manager::start_blocking_operation();
+                        let api = list_unowned_pods().await;
+                        cache_manager::end_blocking_operation();
+                        if let Ok(v) = api {
+                            if !v.is_empty() {
+                                let _ = cache
+                                    .put(&unowned_request, FetchResult::Pods(v.clone()))
+                                    .await;
+                            }
+                            v
+                        } else if let Some(FetchResult::Pods(v)) =
+                            cache.get_or_mark_stale(&unowned_request).await
+                        {
+                            v
+                        } else {
+                            Vec::new()
+                        }
+                    };
+
+                let mut merged = merge_workloads(rs_items, ds_items, ss_items, &unowned_items);
                 if merged != last_sent && tx.send(Message::Rs(merged.clone())).await.is_err() {
                     break;
                 }
@@ -284,22 +343,49 @@ impl AppBehavior for App {
             cache.subscription_manager.unsubscribe(&rs_sub_id).await;
             cache.subscription_manager.unsubscribe(&ds_sub_id).await;
             cache.subscription_manager.unsubscribe(&ss_sub_id).await;
+            cache.subscription_manager.unsubscribe(&pods_sub_id).await;
         });
 
         ReceiverStream::new(rx)
     }
 }
 
-/// Combine `ReplicaSet`, `DaemonSet`, and `StatefulSet` rows into a single
-/// workload list sorted by kind then name, so the landing has a stable order
-/// regardless of which cache updated most recently.
-fn merge_workloads(rs: Vec<Rs>, ds: Vec<Rs>, ss: Vec<Rs>) -> Vec<Rs> {
-    let mut merged = Vec::with_capacity(rs.len() + ds.len() + ss.len());
+/// Combine `ReplicaSet`, `DaemonSet`, `StatefulSet`, and unowned-pod rows
+/// into a single workload list sorted by kind then name, so the landing has
+/// a stable order regardless of which cache updated most recently.
+///
+/// Unowned pods are collapsed into a single synthetic row with
+/// `description = "Unowned"` and a pod count. If there are no unowned pods
+/// the row is omitted.
+fn merge_workloads(rs: Vec<Rs>, ds: Vec<Rs>, ss: Vec<Rs>, unowned: &[RsPod]) -> Vec<Rs> {
+    let mut merged = Vec::with_capacity(rs.len() + ds.len() + ss.len() + 1);
     merged.extend(rs);
     merged.extend(ds);
     merged.extend(ss);
+    if let Some(row) = synthesize_unowned_row(unowned) {
+        merged.push(row);
+    }
     merged.sort_by(|a, b| a.description.cmp(&b.description).then(a.name.cmp(&b.name)));
     merged
+}
+
+/// Collapse the unowned-pod list into a single landing row, or `None` when
+/// the list is empty (so the row doesn't appear on clusters where every pod
+/// has an owner controller).
+fn synthesize_unowned_row(unowned: &[RsPod]) -> Option<Rs> {
+    if unowned.is_empty() {
+        return None;
+    }
+    let count = unowned.len();
+    Some(Rs {
+        name: "(unowned)".to_string(),
+        owner: String::new(),
+        description: "Unowned".to_string(),
+        age: String::new(),
+        pods: format!("{count}"),
+        selectors: None,
+        events: Vec::new(),
+    })
 }
 
 impl App {
@@ -461,16 +547,23 @@ impl App {
         }))
     }
 
-    /// Switch to Pods app
+    /// Switch to Pods app. Routes the synthesized "Unowned" row to a
+    /// selector-less pod list driven by `PodSelector::Unowned`; everything
+    /// else (RS/DS/SS) goes through `PodSelector::ByLabels`.
     fn handle_switch_to_pods(&mut self) -> Apps {
-        if let Some(selection) = self.get_selected_item()
-            && let Some(selectors) = selection.selectors.clone()
-        {
-            let data_vec = vec![];
-            debug!("changing app from rs to pod...");
-            return Apps::Pod {
-                app: pod_app::app::App::new(selectors, data_vec),
-            };
+        if let Some(selection) = self.get_selected_item() {
+            if selection.description == "Unowned" {
+                debug!("changing app from rs to pod (unowned)...");
+                return Apps::Pod {
+                    app: pod_app::app::App::new(PodSelector::Unowned, Vec::new()),
+                };
+            }
+            if let Some(selectors) = selection.selectors.clone() {
+                debug!("changing app from rs to pod...");
+                return Apps::Pod {
+                    app: pod_app::app::App::new(PodSelector::ByLabels(selectors), Vec::new()),
+                };
+            }
         }
         Apps::Rs { app: self.clone() }
     }
@@ -607,7 +700,7 @@ mod tests {
         let ds_list = vec![rs("kube-proxy", "DaemonSet")];
         let ss_list = vec![rs("kafka", "StatefulSet"), rs("etcd", "StatefulSet")];
 
-        let merged = merge_workloads(rs_list, ds_list, ss_list);
+        let merged = merge_workloads(rs_list, ds_list, ss_list, &[]);
 
         let order: Vec<(&str, &str)> = merged
             .iter()
@@ -615,7 +708,7 @@ mod tests {
             .collect();
 
         // DaemonSet < ReplicaSet < StatefulSet (lex order on description),
-        // then by name within each group.
+        // then by name within each group. No Unowned row when list is empty.
         assert_eq!(
             order,
             vec![
@@ -626,5 +719,55 @@ mod tests {
                 ("StatefulSet", "kafka"),
             ]
         );
+    }
+
+    fn pod(name: &str, kind: &str) -> RsPod {
+        RsPod {
+            name: name.to_string(),
+            status: "Running".to_string(),
+            description: kind.to_string(),
+            age: String::new(),
+            containers: "1/1".to_string(),
+            selectors: None,
+            events: Vec::new(),
+            cpu_request: None,
+            cpu_limit: None,
+            cpu_usage: None,
+            memory_request: None,
+            memory_limit: None,
+            memory_usage: None,
+            node_name: None,
+            node_cpu_percent: None,
+            node_memory_percent: None,
+        }
+    }
+
+    #[test]
+    fn merge_workloads_synthesizes_single_unowned_row_sorted_last() {
+        let rs_list = vec![rs("web", "ReplicaSet")];
+        let ds_list = vec![rs("kube-proxy", "DaemonSet")];
+        let ss_list: Vec<Rs> = vec![];
+        let unowned = vec![
+            pod("kube-apiserver-node1", "StaticPod"),
+            pod("kube-scheduler-node1", "StaticPod"),
+        ];
+
+        let merged = merge_workloads(rs_list, ds_list, ss_list, &unowned);
+
+        let last = merged.last().expect("unowned row should be present");
+        assert_eq!(last.description, "Unowned");
+        assert_eq!(last.name, "(unowned)");
+        assert_eq!(last.pods, "2");
+        assert_eq!(
+            merged.iter().filter(|r| r.description == "Unowned").count(),
+            1,
+            "exactly one synthesized Unowned row"
+        );
+    }
+
+    #[test]
+    fn merge_workloads_omits_unowned_row_when_empty() {
+        let merged = merge_workloads(vec![rs("web", "ReplicaSet")], vec![], vec![], &[]);
+        assert!(merged.iter().all(|r| r.description != "Unowned"));
     }
 }

--- a/src/tui/rs_app/app.rs
+++ b/src/tui/rs_app/app.rs
@@ -32,6 +32,11 @@ use tracing::{debug, warn};
 
 const POLL_MS: u64 = 5000;
 
+/// Display string written to `Rs.description` for the synthesized unowned
+/// row. Referenced at synthesis and at route-on-Enter; kept in a constant
+/// so the two sites can't drift.
+const UNOWNED_KIND: &str = "Unowned";
+
 #[derive(Clone, Debug)]
 pub struct App {
     pub(crate) base: BaseTableState<Rs>,
@@ -372,6 +377,11 @@ fn merge_workloads(rs: Vec<Rs>, ds: Vec<Rs>, ss: Vec<Rs>, unowned: &[RsPod]) -> 
 /// Collapse the unowned-pod list into a single landing row, or `None` when
 /// the list is empty (so the row doesn't appear on clusters where every pod
 /// has an owner controller).
+///
+/// `age` is intentionally blank: the row aggregates a heterogeneous set of
+/// pods (e.g. kube-apiserver, etcd, scheduler on kubeadm), so there is no
+/// single meaningful creation time. Per-pod ages are visible one `Enter`
+/// deeper in `pod_app`.
 fn synthesize_unowned_row(unowned: &[RsPod]) -> Option<Rs> {
     if unowned.is_empty() {
         return None;
@@ -380,7 +390,7 @@ fn synthesize_unowned_row(unowned: &[RsPod]) -> Option<Rs> {
     Some(Rs {
         name: "(unowned)".to_string(),
         owner: String::new(),
-        description: "Unowned".to_string(),
+        description: UNOWNED_KIND.to_string(),
         age: String::new(),
         pods: format!("{count}"),
         selectors: None,
@@ -547,12 +557,12 @@ impl App {
         }))
     }
 
-    /// Switch to Pods app. Routes the synthesized "Unowned" row to a
+    /// Switch to Pods app. Routes the synthesized unowned-pods row to a
     /// selector-less pod list driven by `PodSelector::Unowned`; everything
     /// else (RS/DS/SS) goes through `PodSelector::ByLabels`.
     fn handle_switch_to_pods(&mut self) -> Apps {
         if let Some(selection) = self.get_selected_item() {
-            if selection.description == "Unowned" {
+            if selection.description == UNOWNED_KIND {
                 debug!("changing app from rs to pod (unowned)...");
                 return Apps::Pod {
                     app: pod_app::app::App::new(PodSelector::Unowned, Vec::new()),

--- a/src/tui/rs_app/domain.rs
+++ b/src/tui/rs_app/domain.rs
@@ -119,7 +119,10 @@ impl DomainService<Rs> for ReplicaSetDomainService {
                         || Err("No selectors available for selected ReplicaSet".into()),
                         |selectors| {
                             Ok(Some(Apps::Pod {
-                                app: pod_app::app::App::new(selectors.clone(), Vec::new()),
+                                app: pod_app::app::App::new(
+                                    crate::k8s::cache::PodSelector::ByLabels(selectors.clone()),
+                                    Vec::new(),
+                                ),
                             }))
                         },
                     )


### PR DESCRIPTION
  What shipped:
  - PodSelector::Unowned variant — distinct cache key from ByLabels({}), test in fetcher.rs.
  - list_unowned_pods() in src/k8s/pods.rs, plus a shared project_pod / load_pod_projection_inputs / build_node_info helper trio (the old 260-line list_rspods is now ~20 lines).
  - background_fetcher::fetch_data dispatches Unowned → list_unowned_pods, everything else → list_rspods.
  - pod_app::App.selector is now PodSelector (not BTreeMap); 3 call sites updated.
  - rs_app subscribes to pods:*, fetches unowned pods in parallel with RS+DS+SS, and merge_workloads synthesizes a single Unowned row with the pod count (omitted when zero). Enter on that row routes to pod_app with PodSelector::Unowned.
  - Tests: unowned-row-synthesized, empty-case-omitted, existing sort test updated.
  - Design doc marks Slice 3 merged and records the helper extraction.

  Next up per the design doc is Slice 4 (Jobs), where the selector model breaks for the first time.